### PR TITLE
Python 3 support

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+from samplitude import samplitude as s8e
+import unittest
+
+
+class SamplitudeTestCase(unittest.TestCase):
+
+    def __init__(self, methodName='runTest', seed=1729):
+        super().__init__(methodName)
+        self.seed = seed
+
+    def asserts8e(self, template, expected, seed=None):
+        if seed is None:
+            seed = self.seed
+
+        self.assertEqual(str(expected), str(s8e(template, seed=seed)))

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,14 +1,8 @@
 import unittest
-from samplitude import samplitude as s8e
+from tests import SamplitudeTestCase
 
-class TestSamplitudeConsumers(unittest.TestCase):
 
-    def setUp(self):
-        self.seed = 1729
-
-    def asserts8e(self, template, expected):
-        self.assertEqual(str(expected),
-                         str(s8e(template, seed=self.seed)))
+class TestSamplitudeConsumers(SamplitudeTestCase):
 
     def test_tojson(self):
         self.asserts8e("'HT' | choice | sample(6) | counter | tojson",

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -7,7 +7,7 @@ class TestSamplitudeConsumers(SamplitudeTestCase):
     def test_to_json(self):
         self.asserts8e("'HT' | choice | sample(6) | counter | tojson",
                        """\
-{"H": 3, "T": 3}""")
+{"H": 4, "T": 2}""")
 
     def test_max_min_sum_len(self):
         base = 'range(1, 101) | scale(range(100,0,-1))'

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -4,7 +4,7 @@ from tests import SamplitudeTestCase
 
 class TestSamplitudeConsumers(SamplitudeTestCase):
 
-    def test_tojson(self):
+    def test_to_json(self):
         self.asserts8e("'HT' | choice | sample(6) | counter | tojson",
                        """\
 {"H": 3, "T": 3}""")
@@ -15,7 +15,6 @@ class TestSamplitudeConsumers(SamplitudeTestCase):
         self.asserts8e('%s | min' % base, "100")
         self.asserts8e('%s | sum' % base, "171700")
         self.asserts8e('%s | len' % base, "100")
-
 
     def test_gobbler(self):
         base = 'range(1, 101) | scale(range(100,0,-1))'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -10,8 +10,9 @@ class TestSamplitudeFilters(SamplitudeTestCase):
                          s8e('sin(0.1) | round(1) | sample(7) | cli'))
 
     def test_scale(self):
-        self.assertEqual('\n'.join(map(str, list(range(5,15)))),
+        self.assertEqual('\n'.join(map(str, list(range(5, 15)))),
                          s8e('count() | sample(10) | shift(5) | cli'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -9,6 +9,12 @@ class TestSamplitudeFilters(SamplitudeTestCase):
         self.assertEqual('\n'.join(['0.{}'.format(_) for _ in range(7)]),
                          s8e('sin(0.1) | round(1) | sample(7) | cli'))
 
+    def test_rounding(self):
+        base = '[0.5, 0.25, 0.125, 0.0625, 0.03125] | round(%d) | list'
+        self.asserts8e(base % 1, '[0.5, 0.2, 0.1, 0.1, 0.0]')
+        self.asserts8e(base % 2, '[0.5, 0.25, 0.12, 0.06, 0.03]')
+        self.asserts8e(base % 3, '[0.5, 0.25, 0.125, 0.062, 0.031]')
+
     def test_scale(self):
         self.assertEqual('\n'.join(map(str, list(range(5, 15)))),
                          s8e('count() | sample(10) | shift(5) | cli'))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,7 +1,9 @@
 import unittest
 from samplitude import samplitude as s8e
+from tests import SamplitudeTestCase
 
-class TestSamplitudeFilters(unittest.TestCase):
+
+class TestSamplitudeFilters(SamplitudeTestCase):
 
     def test_round(self):
         self.assertEqual('\n'.join(['0.{}'.format(_) for _ in range(7)]),

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -13,7 +13,6 @@ class TestSamplitudeGenerators(SamplitudeTestCase):
         self.asserts8e('range(10) | sum',
                        '45')
 
-
     def test_normal(self):
         self.asserts8e('normal(170, 10) | sample(3) | round | cli',
                        """\
@@ -51,6 +50,7 @@ class TestSamplitudeGenerators(SamplitudeTestCase):
     def test_chi2(self):
         self.asserts8e('chi2(5) | sample(3) | round | len',
                        '3')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,15 +1,9 @@
 import unittest
 from samplitude import samplitude as s8e
+from tests import SamplitudeTestCase
 
-class TestSamplitudeGenerators(unittest.TestCase):
 
-    def setUp(self):
-        self.seed = 1729
-
-    def asserts8e(self, template, expected):
-        self.assertEqual(str(expected),
-                         str(s8e(template, seed=self.seed)))
-
+class TestSamplitudeGenerators(SamplitudeTestCase):
 
     def test_compact_print(self):
         self.assertEqual('"range(8) | shift(2) | sample(3)"',

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -14,38 +14,20 @@ class TestSamplitudeGenerators(SamplitudeTestCase):
                        '45')
 
     def test_normal(self):
-        self.asserts8e('normal(170, 10) | sample(3) | round | cli',
-                       """\
-167.178
-173.51
-164.402""")
-        self.asserts8e('gauss(170, 10) | sample(3) | round | cli',
-                       """\
-190.785
-169.526
-160.629""")
+        self.asserts8e('normal(170, 10) | sample(3) | round | list',
+                       '[167.178, 173.51, 164.402]')
+        self.asserts8e('gauss(170, 10) | sample(3) | round | list',
+                       '[190.785, 169.526, 160.629]')
 
     def test_uniform(self):
-        self.asserts8e('uniform(0, 42) | sample(3) | round | cli',
-                       """\
-41.848
-37.162
-17.254""")
-
+        self.asserts8e('uniform(0, 42) | sample(3) | round | list',
+                       '[41.848, 37.162, 17.254]')
 
     def test_exponential(self):
-        self.asserts8e('exponential(1/2.71828) | round | sample(3) | cli',
-                       """\
-15.274
-5.875
-1.438""")
-        self.asserts8e('poisson(1/2.71828) | round | sample(3) | cli',
-                       """\
-15.274
-5.875
-1.438""")
-
-
+        self.asserts8e('exponential(1/2.71828) | round | sample(3) | list',
+                       '[15.274, 5.875, 1.438]')
+        self.asserts8e('poisson(1/2.71828) | round | sample(3) | list',
+                       '[15.274, 5.875, 1.438]')
 
     def test_chi2(self):
         self.asserts8e('chi2(5) | sample(3) | round | len',

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -19,8 +19,6 @@ class TestReadme(SamplitudeTestCase):
 0.951
 1.0""")
 
-
-
     def test_intro_head(self):
         self.asserts8e("sin(0.31415) | head(6) | round | cli",
                        """0.0
@@ -30,7 +28,6 @@ class TestReadme(SamplitudeTestCase):
 0.951
 1.0""")
 
-
     def test_intro_drop(self):
         self.asserts8e("sin(0.31415) | drop(2) | head(4) | round | cli",
                        """0.588
@@ -38,11 +35,9 @@ class TestReadme(SamplitudeTestCase):
 0.951
 1.0""")
 
-
     def test_sin_max(self):
         self.asserts8e("sin(0.31415) | sample(5) | round | max | cli",
                        '0.951')
-
 
     def test_poisson_scale(self):
         self.asserts8e("poisson(0.3) | round | shift(15) | sample(5) |cli",
@@ -65,7 +60,6 @@ class TestReadme(SamplitudeTestCase):
         self.asserts8e("file('data/iris.csv') | sample(1) | cli",
                        "150,4,setosa,versicolor,virginica")
 
-
     def test_permutations_join(self):
         self.asserts8e("'HT' | permutations | cli",
                        """\
@@ -82,8 +76,6 @@ T;H""")
         self.asserts8e("range(10) | permutations | len",
                        '3628800')
 
-
-
     def test_pure_jinja(self):
         self.asserts8e("range(5) | list",
                        '[0, 1, 2, 3, 4]')
@@ -97,7 +89,7 @@ T;H""")
 3
 4""")
 
-    def test_countsamplecli(self):
+    def test_count_sample_cli(self):
         self.asserts8e("count() | sample(5) | cli",
                        """\
 0
@@ -124,7 +116,6 @@ T;H""")
 2.29
 3.34""")
 
-
     def test_even_choice(self):
         self.asserts8e("range(0, 11, 2) | choice | sample(6) | cli",
                        """\
@@ -135,8 +126,7 @@ T;H""")
 8
 2""")
 
-
-    def test_coinflip(self):
+    def test_coin_flip(self):
         self.asserts8e("'HT' | choice | sample(6) | cli",
                        """\
 T

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -101,11 +101,11 @@ T;H""")
     def test_uniform(self):
         self.asserts8e("uniform(0, 5) | sample(5) | cli",
                        """\
-4.98186188391
-4.42410048265
-2.05399187287
-2.28859745598
-3.33617203154""")
+4.981861883913835
+4.424100482649073
+2.0539918728658444
+2.2885974559805384
+3.336172031543227""")
 
     def test_uniform_round(self):
         self.asserts8e("uniform(0, 5) | round(2) | sample(5) | cli",
@@ -120,45 +120,44 @@ T;H""")
         self.asserts8e("range(0, 11, 2) | choice | sample(6) | cli",
                        """\
 10
-10
-4
-4
+0
+6
 8
+6
 2""")
 
     def test_coin_flip(self):
         self.asserts8e("'HT' | choice | sample(6) | cli",
                        """\
+H
 T
 T
 H
 H
-T
 H""")
 
     def test_count_dice_seed42(self):
-        self.seed = 42
         self.asserts8e("range(1,7) | choice | sample(100) | counter | sort | elt_join | cli",
                        """\
-1 17
-2 21
-3 12
-4 21
-5 13
-6 16""")
+1 20
+2 18
+3 17
+4 11
+5 14
+6 20""",
+                       seed=42)
 
     def test_count_dice_seed42_sort(self):
-        self.seed = 42
         self.asserts8e("range(1,7) | choice | sample(100) |\
                         counter | swap | sort | swap | elt_join | cli",
                        """\
-3 12
-5 13
-6 16
-1 17
-2 21
-4 21""")
-
+4 11
+5 14
+3 17
+2 18
+1 20
+6 20""",
+                       seed=42)
 
     def test_win_draw_loss(self):
         self.asserts8e("['win', 'draw', 'loss'] | choice | sample(6) | sort | cli",
@@ -167,7 +166,7 @@ draw
 draw
 loss
 loss
-loss
+win
 win""")
 
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,7 +1,11 @@
 import unittest
 from tests import SamplitudeTestCase
 
-class TestReadme(unittest.TestCase):
+try:
+    import pandas
+    pandas_is_importable = True
+except ImportError as err:
+    pandas_is_importable = False
 
 
 class TestReadme(SamplitudeTestCase):
@@ -49,7 +53,7 @@ class TestReadme(SamplitudeTestCase):
 17.04
 18.668""")
 
-
+    @unittest.skipIf(not pandas_is_importable, "Unable to import Pandas")
     def test_csv_counter(self):
         self.asserts8e("csv('data/iris.csv', 'virginica') | counter | cli",
                          """\

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,14 +1,10 @@
 import unittest
-from samplitude import samplitude as s8e
+from tests import SamplitudeTestCase
 
 class TestReadme(unittest.TestCase):
 
-    def setUp(self):
-        self.seed = 1729
 
-    def asserts8e(self, template, expected):
-        self.assertEqual(str(expected),
-                         str(s8e(template, seed=self.seed)))
+class TestReadme(SamplitudeTestCase):
 
     def test_intro(self):
         self.asserts8e("sin(0.31415) | sample(6) | round | cli",

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -44,7 +44,7 @@ class TestReadme(SamplitudeTestCase):
                        """\
 33.731
 22.204
-16.763
+16.762999999999998
 17.04
 18.668""")
 


### PR DESCRIPTION
Python 3.2 changed how seeds are used to set up a Random number generator. This updates the tests to support Python 3 instead of Python 2.