### PR TITLE
Add support for combining choice with sample

### DIFF
--- a/samplitude/__init__.py
+++ b/samplitude/__init__.py
@@ -23,26 +23,26 @@ s8e.generator('cos', cosinegenerator, infinite=True)
 s8e.generator('tan', tangenerator, infinite=True)
 
 
-class _LengthyGenerator(object):
-    def __init__(self, dist, n):
-        if not hasattr(dist, '__next__'):
-            self.dist = iter(dist)
+class _SizedIterator(object):
+    def __init__(self, elements, n):
+        if not hasattr(elements, '__next__'):
+            self._elements = iter(elements)
         else:
-            self.dist = dist
-        self.n = n
-        self.i = 0
+            self._elements = elements
+        self._n = n
+        self._i = 0
 
     def __len__(self):
-        return self.n
+        return self._n
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if self.i == self.n:
+        if self._i == self._n:
             raise StopIteration
-        v = next(self.dist)
-        self.i += 1
+        v = next(self._elements)
+        self._i += 1
         return v
 
 
@@ -227,12 +227,12 @@ def _shift(gen, s=0):
 
 @s8e.filter('sample', limiter=True)
 def _sample(dist, n):
-    return _LengthyGenerator(dist, n)
+    return _SizedIterator(dist, n)
 
 
 @s8e.filter('head', limiter=True)
 def _head(dist, n=5):
-    return _LengthyGenerator(dist, n)
+    return _SizedIterator(dist, n)
 
 
 @s8e.filter('swap')
@@ -468,7 +468,7 @@ def samplitude(tmpl, seed=None, filters=None):
     if res is None:
         return
 
-    if res.startswith('<samplitude._LengthyGenerator'):
+    if res.startswith('<samplitude._SizedIterator'):
         tmpl = tmpl[3:-3].split('|')
         return '"{}"'.format(' | '.join(map(str.strip, tmpl)))
     return res

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -24,6 +24,11 @@ class TestSamplitudeExpressions(SamplitudeTestCase):
         with self.assertRaises(ValueError):
             self.asserts8e("poisson(0.3) | sample(2) | choice", '')
 
+    def test_to_json_of_sized_iterator(self):
+        #  TODO: Add support for custom JSON Encoder?
+        with self.assertRaises(TypeError):
+            self.asserts8e('"ABC"| choice | sample(5) | tojson', '')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -20,6 +20,10 @@ class TestSamplitudeExpressions(SamplitudeTestCase):
         with self.assertRaises(ValueError):
             self.asserts8e("poisson(0.3) | sample(2) | list | choice", '')
 
+    def test_sample_generator_with_len(self):
+        with self.assertRaises(ValueError):
+            self.asserts8e("poisson(0.3) | sample(2) | choice", '')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -33,6 +33,10 @@ class TestSamplitudeGenerators(SamplitudeTestCase):
         self.asserts8e('chi2(5) | sample(3) | round | len',
                        '3')
 
+    def test_range_head(self):
+        self.asserts8e('range(10) | head | list',
+                       '[0, 1, 2, 3, 4]')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`sample` (and `head`) produces an `iterable` that is incompatible with `choice`. This PR adds a `__len__` to the `sample` and `head` filters so that their results can be used in conjunction with the `choice` filter.